### PR TITLE
Fix Purpose and Use display, save & export

### DIFF
--- a/igamt-lite-client/app/views/edit/editDatatypes.html
+++ b/igamt-lite-client/app/views/edit/editDatatypes.html
@@ -94,7 +94,7 @@
                                         <label class="col-md-2 control-label">Purpose and Use</label>
 
                                         <div class="controls col-md-10">
-                                            <textarea rows="3" cols="20" ng-disabled="viewSettings.tableReadonly || (datatype.scope === 'HL7STANDARD' || datatype.scope === 'MASTER')" ng-change="setDirty()" name="purposeUse" id="purposeUse" class="form-control" ng-model="datatype.purposeUse" />
+                                            <textarea rows="3" cols="20" ng-disabled="viewSettings.tableReadonly || (datatype.scope === 'HL7STANDARD' || datatype.scope === 'MASTER')" ng-change="setDirty()" name="purposeUse" id="purposeUse" class="form-control" ng-model="datatype.purposeAndUse" />
                                         </div>
                                     </div>
                                     <div class="form-group control-group" ng-class="{'igl-has-error has-feedback' : editForm.comment.$invalid}">

--- a/igamt-lite-service/src/main/java/gov/nist/healthcare/tools/hl7/v2/igamt/lite/service/impl/Serialization4ExportImpl.java
+++ b/igamt-lite-service/src/main/java/gov/nist/healthcare/tools/hl7/v2/igamt/lite/service/impl/Serialization4ExportImpl.java
@@ -1775,6 +1775,7 @@ public class Serialization4ExportImpl implements IGDocumentSerialization {
 				elmDatatype.addAttribute(new Attribute("Name", d.getName()));
 				elmDatatype.addAttribute(new Attribute("Label", d.getLabel()));
 				elmDatatype.addAttribute(new Attribute("Description", d.getDescription()));
+				elmDatatype.addAttribute(new Attribute("PurposeAndUse", d.getPurposeAndUse()));
 				elmDatatype.addAttribute(new Attribute("Comment", d.getComment()));
 				elmDatatype
 						.addAttribute(new Attribute("Hl7Version", d.getHl7Version() == null ? "" : d.getHl7Version()));// TODO

--- a/igamt-lite-service/src/main/resources/rendering/templates/profile/datatype.xsl
+++ b/igamt-lite-service/src/main/resources/rendering/templates/profile/datatype.xsl
@@ -2,15 +2,17 @@
     <xsl:import href="/rendering/templates/profile/component.xsl"/>
     <xsl:import href="/rendering/templates/profile/constraint.xsl"/>
     <xsl:template match="Datatype">
-        <xsl:if test="count(Text[@Type='PurposeAndUse']) &gt; 0">
+        <xsl:if test="not(@PurposeAndUse='')">
             <xsl:element name="p">
+                <xsl:element name="b"><xsl:text>Purpose and Use: </xsl:text></xsl:element>
                 <xsl:value-of disable-output-escaping="yes"
-                              select="Text[@Type='PurposeAndUse']"/>
+                              select="@PurposeAndUse"/>
             </xsl:element>
         </xsl:if>
         <xsl:value-of select="@Comment"></xsl:value-of>
         <xsl:if test="count(Text[@Type='UsageNote']) &gt; 0">
             <xsl:element name="p">
+                <xsl:element name="b"><xsl:text>Usage note: </xsl:text></xsl:element>
                 <xsl:value-of disable-output-escaping="yes"
                               select="Text[@Type='UsageNote']"/>
             </xsl:element>


### PR DESCRIPTION
QA: Fill the "Purpose and Use" field in a datatype, and check that it's saved (click on another datatype and then come back to the one you modified, the field should be populated) and exported in the word and html documents.