### PR TITLE
Fix export error with global conformance statements

### DIFF
--- a/igamt-lite-service/src/main/java/gov/nist/healthcare/tools/hl7/v2/igamt/lite/service/impl/Serialization4ExportImpl.java
+++ b/igamt-lite-service/src/main/java/gov/nist/healthcare/tools/hl7/v2/igamt/lite/service/impl/Serialization4ExportImpl.java
@@ -743,8 +743,13 @@ public class Serialization4ExportImpl implements IGDocumentSerialization {
 		nu.xom.Element elmConstraint = new nu.xom.Element("Constraint");
 		elmConstraint.addAttribute(
 				new Attribute("Id", constraint.getConstraintId() == null ? "" : constraint.getConstraintId()));
-		elmConstraint.addAttribute(new Attribute("Location",
-				constraint.getConstraintTarget().substring(0, constraint.getConstraintTarget().indexOf('['))));
+			if(null!=constraint.getConstraintTarget()&&constraint.getConstraintTarget().length()>"[".length()) {
+					elmConstraint.addAttribute(new Attribute("Location", constraint.getConstraintTarget()
+							.substring(0, constraint.getConstraintTarget().indexOf('['))));
+			} else {
+					//TODO report the error correctly
+					elmConstraint.addAttribute(new Attribute("Location",""));
+			}
 		elmConstraint.addAttribute(new Attribute("LocationName", locationName));
 		elmConstraint.appendChild(constraint.getDescription());
 		if (constraint instanceof Predicate) {


### PR DESCRIPTION
@haffonist @Jungyubw  QA: Create an IG with a global conformance statement with Woo's popup and export the document.
I left a TODO because I don't know how @olivier-m-mr handles the error reporting, so I'll fix this later when I have some time to discuss this with him. Also, if the constraintTarget attribute is null or empty I just set the Location to "", is that correct?