### PR TITLE
Fix/issue#440

### DIFF
--- a/igamt-lite-service/src/main/java/gov/nist/healthcare/tools/hl7/v2/igamt/lite/service/impl/Serialization4ExportImpl.java
+++ b/igamt-lite-service/src/main/java/gov/nist/healthcare/tools/hl7/v2/igamt/lite/service/impl/Serialization4ExportImpl.java
@@ -1109,10 +1109,10 @@ public class Serialization4ExportImpl implements IGDocumentSerialization {
 
 				if ((t != null && !t.getDefPreText().isEmpty()) || (t != null && !t.getDefPostText().isEmpty())) {
 					if (t.getDefPreText() != null && !t.getDefPreText().isEmpty()) {
-						elmTableDefinition.appendChild(this.serializeRichtext("Text1", t.getDefPreText()));
+						elmTableDefinition.appendChild(this.serializeRichtext("DefPreText", t.getDefPreText()));
 					}
 					if (t.getDefPostText() != null && !t.getDefPostText().isEmpty()) {
-						elmTableDefinition.appendChild(this.serializeRichtext("Text2", t.getDefPostText()));
+						elmTableDefinition.appendChild(this.serializeRichtext("DefPostText", t.getDefPostText()));
 					}
 				}
 
@@ -1544,10 +1544,10 @@ public class Serialization4ExportImpl implements IGDocumentSerialization {
 				if ((s.getText1() != null && !s.getText1().isEmpty())
 						|| (s.getText2() != null && !s.getText2().isEmpty())) {
 					if (s.getText1() != null && !s.getText1().isEmpty()) {
-						elmSegment.appendChild(this.serializeRichtext("Text1", s.getText1()));
+						elmSegment.appendChild(this.serializeRichtext("DefPreText", s.getText1()));
 					}
 					if (s.getText2() != null && !s.getText2().isEmpty()) {
-						elmSegment.appendChild(this.serializeRichtext("Text2", s.getText2()));
+						elmSegment.appendChild(this.serializeRichtext("DefPostText", s.getText2()));
 					}
 				}
 
@@ -1864,10 +1864,10 @@ public class Serialization4ExportImpl implements IGDocumentSerialization {
 
 					if ((d != null && !d.getDefPreText().isEmpty()) || (d != null && !d.getDefPostText().isEmpty())) {
 						if (d.getDefPreText() != null && !d.getDefPreText().isEmpty()) {
-							elmDatatype.appendChild(this.serializeRichtext("PreText", d.getDefPreText()));
+							elmDatatype.appendChild(this.serializeRichtext("DefPreText", d.getDefPreText()));
 						}
 						if (d.getDefPostText() != null && !d.getDefPostText().isEmpty()) {
-							elmDatatype.appendChild(this.serializeRichtext("PostText", d.getDefPostText()));
+							elmDatatype.appendChild(this.serializeRichtext("DefPostText", d.getDefPostText()));
 						}
 					}
 					if (d.getUsageNote() != null && !d.getUsageNote().isEmpty()) {

--- a/igamt-lite-service/src/main/java/gov/nist/healthcare/tools/hl7/v2/igamt/lite/service/impl/Serialization4ExportImpl.java
+++ b/igamt-lite-service/src/main/java/gov/nist/healthcare/tools/hl7/v2/igamt/lite/service/impl/Serialization4ExportImpl.java
@@ -1030,6 +1030,14 @@ public class Serialization4ExportImpl implements IGDocumentSerialization {
 						elmTableDefinition.appendChild(elmTableElement);
 					}
 				}
+					if ((t != null && !t.getDefPreText().isEmpty()) || (t != null && !t.getDefPostText().isEmpty())) {
+							if (t.getDefPreText() != null && !t.getDefPreText().isEmpty()) {
+									elmTableDefinition.appendChild(this.serializeRichtext("DefPreText", t.getDefPreText()));
+							}
+							if (t.getDefPostText() != null && !t.getDefPostText().isEmpty()) {
+									elmTableDefinition.appendChild(this.serializeRichtext("DefPostText", t.getDefPostText()));
+							}
+					}
 				sect.appendChild(elmTableDefinition);
 				return sect;
 			} else {

--- a/igamt-lite-service/src/main/resources/rendering/templates/profile/datatype.xsl
+++ b/igamt-lite-service/src/main/resources/rendering/templates/profile/datatype.xsl
@@ -1,6 +1,7 @@
 <xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
     <xsl:import href="/rendering/templates/profile/component.xsl"/>
     <xsl:import href="/rendering/templates/profile/constraint.xsl"/>
+    <xsl:import href="/rendering/templates/profile/definitionText.xsl"/>
     <xsl:template match="Datatype">
         <xsl:if test="not(@PurposeAndUse='')">
             <xsl:element name="p">
@@ -17,14 +18,12 @@
                               select="Text[@Type='UsageNote']"/>
             </xsl:element>
         </xsl:if>
-        <xsl:if test="count(./Text[@Type='PreText']) &gt; 0">
-            <xsl:element name="h4">
-                <xsl:text>Pre-definition:</xsl:text>
-            </xsl:element>
-            <xsl:element name="p">
-                <xsl:value-of disable-output-escaping="yes"
-                              select="./Text[@Type='PreText']" />
-            </xsl:element>
+        <xsl:if test="count(./Text[@Type='DefPreText']) &gt; 0">
+            <xsl:call-template name="definitionText">
+                <xsl:with-param name="type">
+                    <xsl:text>pre</xsl:text>
+                </xsl:with-param>
+            </xsl:call-template>
         </xsl:if>
         <xsl:element name="p">
             <xsl:element name="table">
@@ -155,22 +154,12 @@
                 </xsl:if>
             </xsl:for-each>
         </xsl:if>
-        <xsl:if test="count(./Text[@Type='PostText']) &gt; 0">
-            <xsl:element name="h4">
-                <xsl:text>Post-definition:</xsl:text>
-            </xsl:element>
-            <xsl:if test="count(./Text[@Type='Text']) &gt; 0">
-                <xsl:element name="p">
-                    <xsl:element name="u">
-                        <xsl:value-of select="./Text[@Type='Name']"/>
-                        <xsl:text>:</xsl:text>
-                    </xsl:element>
-                    <xsl:value-of disable-output-escaping="yes" select="./Text[@Type='Text']"/>
-                </xsl:element>
-            </xsl:if>
-            <xsl:element name="p">
-                <xsl:value-of disable-output-escaping="yes" select="./Text[@Type='PostText']"/>
-            </xsl:element>
+        <xsl:if test="count(./Text[@Type='DefPostText']) &gt; 0">
+            <xsl:call-template name="definitionText">
+                <xsl:with-param name="type">
+                    <xsl:text>post</xsl:text>
+                </xsl:with-param>
+            </xsl:call-template>
         </xsl:if>
     </xsl:template>
 

--- a/igamt-lite-service/src/main/resources/rendering/templates/profile/definitionText.xsl
+++ b/igamt-lite-service/src/main/resources/rendering/templates/profile/definitionText.xsl
@@ -1,0 +1,34 @@
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+
+    <xsl:template name="definitionText">
+        <xsl:param name="type"/>
+        <xsl:element name="h4">
+            <xsl:choose>
+                <xsl:when test="$type='pre'"><xsl:text>Pre-definition:</xsl:text></xsl:when>
+                <xsl:when test="$type='post'"><xsl:text>Post-definition:</xsl:text></xsl:when>
+            </xsl:choose>
+        </xsl:element>
+        <xsl:element name="p">
+            <xsl:choose>
+                <xsl:when test="$type='pre'">
+                    <xsl:value-of disable-output-escaping="yes"
+                                  select="./Text[@Type='DefPreText']" />
+                </xsl:when>
+                <xsl:when test="$type='post'">
+                    <xsl:if test="count(./Text[@Type='Text']) &gt; 0">
+                        <xsl:element name="p">
+                            <xsl:element name="u">
+                                <xsl:value-of select="./Text[@Type='Name']"/>
+                                <xsl:text>:</xsl:text>
+                            </xsl:element>
+                            <xsl:value-of disable-output-escaping="yes" select="./Text[@Type='Text']"/>
+                        </xsl:element>
+                    </xsl:if>
+                    <xsl:value-of disable-output-escaping="yes"
+                                  select="./Text[@Type='DefPostText']" />
+                </xsl:when>
+            </xsl:choose>
+        </xsl:element>
+    </xsl:template>
+
+</xsl:stylesheet>

--- a/igamt-lite-service/src/main/resources/rendering/templates/profile/message.xsl
+++ b/igamt-lite-service/src/main/resources/rendering/templates/profile/message.xsl
@@ -4,6 +4,13 @@
     <xsl:include href="/rendering/templates/profile/constraint.xsl"/>
     <xsl:template match="MessageDisplay">
         <xsl:value-of select="@Comment"/>
+        <xsl:if test="count(Text[@Type='UsageNote']) &gt; 0">
+            <xsl:element name="p">
+                <xsl:element name="h4"><xsl:text>Definition text</xsl:text></xsl:element>
+                <xsl:value-of disable-output-escaping="yes"
+                              select="Text[@Type='UsageNote']"/>
+            </xsl:element>
+        </xsl:if>
         <xsl:element name="p">
             <xsl:element name="table">
                 <xsl:attribute name="class">

--- a/igamt-lite-service/src/main/resources/rendering/templates/profile/segment.xsl
+++ b/igamt-lite-service/src/main/resources/rendering/templates/profile/segment.xsl
@@ -15,11 +15,12 @@
     <xsl:template match="Segment">
         <xsl:param name="inlineConstraint"/>
         <xsl:value-of select="@Comment"/>
-        <xsl:if test="count(./Text[@Type='Text1']) &gt; 0">
-            <xsl:element name="p">
-                <xsl:value-of disable-output-escaping="yes"
-                              select="./Text[@Type='Text1']" />
-            </xsl:element>
+        <xsl:if test="count(./Text[@Type='DefPreText']) &gt; 0">
+            <xsl:call-template name="definitionText">
+                <xsl:with-param name="type">
+                    <xsl:text>pre</xsl:text>
+                </xsl:with-param>
+            </xsl:call-template>
         </xsl:if>
         <xsl:element name="p">
             <xsl:element name="table">
@@ -166,8 +167,13 @@
             </xsl:if>
         </xsl:if>
 
-        <xsl:value-of disable-output-escaping="yes"
-                      select="./Text[@Type='Text2']" />
+        <xsl:if test="count(./Text[@Type='DefPostText']) &gt; 0">
+            <xsl:call-template name="definitionText">
+                <xsl:with-param name="type">
+                    <xsl:text>post</xsl:text>
+                </xsl:with-param>
+            </xsl:call-template>
+        </xsl:if>
 
         <xsl:for-each select="Field">
             <xsl:sort select="@Position" data-type="number"></xsl:sort>

--- a/igamt-lite-service/src/main/resources/rendering/templates/profile/valueSet.xsl
+++ b/igamt-lite-service/src/main/resources/rendering/templates/profile/valueSet.xsl
@@ -11,6 +11,13 @@
     </xsl:template>
 
     <xsl:template match="ValueSetDefinition">
+        <xsl:if test="count(./Text[@Type='DefPreText']) &gt; 0">
+            <xsl:call-template name="definitionText">
+                <xsl:with-param name="type">
+                    <xsl:text>pre</xsl:text>
+                </xsl:with-param>
+            </xsl:call-template>
+        </xsl:if>
         <xsl:if test="@Stability != ''">
             <xsl:element name="p">
                 <xsl:text>Stability: </xsl:text>
@@ -88,6 +95,13 @@
             </xsl:element>
 
         </xsl:element>
+        <xsl:if test="count(./Text[@Type='DefPostText']) &gt; 0">
+            <xsl:call-template name="definitionText">
+                <xsl:with-param name="type">
+                    <xsl:text>post</xsl:text>
+                </xsl:with-param>
+            </xsl:call-template>
+        </xsl:if>
 
     </xsl:template>
 


### PR DESCRIPTION
QA: Add pre-definition and post-definition text to a datatype, a value set, a segment and a definition text to a conformance profile and check that it is exported