### PR TITLE
Working on issue #1030

### DIFF
--- a/igamt-lite-service/pom.xml
+++ b/igamt-lite-service/pom.xml
@@ -162,12 +162,12 @@
 		<dependency>
 			<groupId>org.docx4j</groupId>
 			<artifactId>docx4j-ImportXHTML</artifactId>
-			<version>3.2.2</version>
+			<version>3.3.1</version>
 		</dependency>
 		<dependency>
 			<groupId>org.docx4j</groupId>
 			<artifactId>docx4j</artifactId>
-			<version>3.2.2</version>
+			<version>3.3.1</version>
 		</dependency>
 		<dependency>
 			<groupId>fr.opensagres.xdocreport</groupId>

--- a/igamt-lite-service/src/main/java/gov/nist/healthcare/tools/hl7/v2/igamt/lite/service/util/SerializationUtil.java
+++ b/igamt-lite-service/src/main/java/gov/nist/healthcare/tools/hl7/v2/igamt/lite/service/util/SerializationUtil.java
@@ -30,6 +30,9 @@ public class SerializationUtil {
   }
 
   public String cleanRichtext(String richtext) {
+    richtext = richtext.replace("<br>", "<br></br>");
+    richtext = richtext.replace("<p style=\"\"><br></p>", "<p></p>");
+
     org.jsoup.nodes.Document doc = Jsoup.parse(richtext);
     Elements elements1 = doc.select("h1");
     elements1.tagName("p").attr("style",
@@ -72,6 +75,12 @@ public class SerializationUtil {
             elementImg.attr("src", texEncImg);
           }
         }
+        if (elementImg.attr("alt") == null || elementImg.attr("alt").isEmpty()){
+          elementImg.attr("alt", ".");
+      }
+      String imgStyle = elementImg.attr("style");
+      elementImg.attr("style", imgStyle.replace("px;", ";"));
+//    style="width: 300px;
       } catch (RuntimeException e) {
         e.printStackTrace(); // If error, we leave the original document
         // as is.
@@ -80,6 +89,15 @@ public class SerializationUtil {
         // as is.
       }
     }
+    for (org.jsoup.nodes.Element elementTbl : doc.select("table")) {
+      if (elementTbl.attr("summary") == null || elementTbl.attr("summary").isEmpty()) {
+          elementTbl.attr("summary", ".");
+      }
+  }
+
+    //Renaming strong to work as html4 
+    doc.select("strong").tagName("b");
+
     return "<div class=\"fr-view\">" + doc.body().html() + "</div>";
   }
 


### PR DESCRIPTION
- Issue with display of bold text is fixed.

- Emoji are background images within span tag e.g. <span class=\"fr-emoticon fr-deletable fr-emoticon-img\" style=\"background: url(https://cdnjs.cloudflare.com/ajax/libs/emojione/2.0.1/assets/svg/1f601.svg);\">&nbsp;</span> => do we want to parse all span, curl the image and encode as b64?

- Uppercased is css classes. To add functionality, we would need to parse p tags and apply toUpper(). Do we want to do that?
