### PR TITLE
Fix segment definition table used concept domain rather than value set

### DIFF
--- a/igamt-lite-service/src/main/resources/rendering/templates/profile/datatype.xsl
+++ b/igamt-lite-service/src/main/resources/rendering/templates/profile/datatype.xsl
@@ -97,7 +97,7 @@
                             <xsl:text>Length</xsl:text>
                         </xsl:element>
                         <xsl:element name="th">
-                            <xsl:text>Concept Domain</xsl:text>
+                            <xsl:text>Value Set</xsl:text>
                         </xsl:element>
                         <xsl:element name="th">
                             <xsl:text>Comment</xsl:text>

--- a/igamt-lite-service/src/main/resources/rendering/templates/profile/segment.xsl
+++ b/igamt-lite-service/src/main/resources/rendering/templates/profile/segment.xsl
@@ -94,7 +94,7 @@
                             <xsl:text>Length</xsl:text>
                         </xsl:element>
                         <xsl:element name="th">
-                            <xsl:text>Concept Domain</xsl:text>
+                            <xsl:text>Value Set</xsl:text>
                         </xsl:element>
                         <xsl:element name="th">
                             <xsl:text>Comment</xsl:text>


### PR DESCRIPTION
@haffonist **Please check that we want to do it for the datatypes as well**
Fix #1041 