### PR TITLE
Display all the datatypes in the verbose export, not only the user ones

### DIFF
--- a/igamt-lite-service/src/main/java/gov/nist/healthcare/tools/hl7/v2/igamt/lite/service/impl/SerializationServiceImpl.java
+++ b/igamt-lite-service/src/main/java/gov/nist/healthcare/tools/hl7/v2/igamt/lite/service/impl/SerializationServiceImpl.java
@@ -171,10 +171,10 @@ import java.util.UUID;
                 .serializeDatatype(datatypeLink,
                     prefix + "." + String.valueOf(datatypeLinkList.indexOf(datatypeLink) + 1),
                     datatypeLinkList.indexOf(datatypeLink));
-            //TODO check if we should use the scope or not
-            if(serializeMaster||!(serializableDatatype.getDatatype().getScope().equals(Constant.SCOPE.HL7STANDARD))){
+            //This "if" is only useful if we want to display only user datatypes
+            //if(serializeMaster||!(serializableDatatype.getDatatype().getScope().equals(Constant.SCOPE.HL7STANDARD))){
                 datatypeSection.addSection(serializableDatatype);
-            }
+            //}
         }
         return datatypeSection;
     }


### PR DESCRIPTION
Fix #1051 