### PR TITLE
Leave usage empty when a VS has no value

### DIFF
--- a/igamt-lite-domain/src/main/java/gov/nist/healthcare/tools/hl7/v2/igamt/lite/domain/serialization/SerializableTable.java
+++ b/igamt-lite-domain/src/main/java/gov/nist/healthcare/tools/hl7/v2/igamt/lite/domain/serialization/SerializableTable.java
@@ -71,7 +71,7 @@ public class SerializableTable extends SerializableSection {
                     valueElement.addAttribute(new Attribute("CodeSystem",
                         (c.getCodeSystem() == null) ? "" : c.getCodeSystem()));
                     valueElement.addAttribute(
-                        new Attribute("Usage", (c.getCodeUsage() == null) ? "" : c.getCodeUsage()));
+                        new Attribute("Usage", (c.getCodeUsage() == null) || c.getValue() ==null || "".equals(c.getValue()) || "...".equals(c.getValue()) ? "" : c.getCodeUsage()));
                     valueElement.addAttribute(
                         new Attribute("Comments", (c.getComments() == null) ? "" : c.getComments()));
                     valueSetDefinitionElement.appendChild(valueElement);


### PR DESCRIPTION
Fix #938 