### PR TITLE
Feature/ticket#2392

### DIFF
--- a/igamt-lite-client/app/views/edit/exportConfig/IGStyle.html
+++ b/igamt-lite-client/app/views/edit/exportConfig/IGStyle.html
@@ -394,6 +394,16 @@
 							ng-change="setChanged()"> <label
 							style="color: black">Content Definition</label></md-checkbox>
 						<br />
+						<md-checkbox class="md-primary"
+							ng-model="IGStyleExportConfig.valueSetsMetadata.oid"
+							ng-change="setChanged()"> <label
+							style="color: black">OID</label></md-checkbox>
+						<br />
+						<md-checkbox class="md-primary"
+							ng-model="IGStyleExportConfig.valueSetsMetadata.type"
+							ng-change="setChanged()"> <label
+							style="color: black">Type</label></md-checkbox>
+						<br />
 					</div>
 				</div>
 			</div>

--- a/igamt-lite-client/app/views/edit/exportConfig/ProfileStyle.html
+++ b/igamt-lite-client/app/views/edit/exportConfig/ProfileStyle.html
@@ -421,6 +421,16 @@
 								ng-change="setChanged()"> <label
 								style="color: black">Content Definition</label></md-checkbox>
 							<br />
+							<md-checkbox class="md-primary"
+								ng-model="profileStyleExportConfig.valueSetsMetadata.oid"
+								ng-change="setChanged()"> <label
+								style="color: black">OID</label></md-checkbox>
+							<br />
+							<md-checkbox class="md-primary"
+								ng-model="profileStyleExportConfig.valueSetsMetadata.type"
+								ng-change="setChanged()"> <label
+								style="color: black">Type</label></md-checkbox>
+							<br />
 						</div>
 					</div>
 				</div>

--- a/igamt-lite-client/app/views/edit/exportConfig/TableStyle.html
+++ b/igamt-lite-client/app/views/edit/exportConfig/TableStyle.html
@@ -414,6 +414,16 @@
 							ng-change="setChanged()"> <label
 							style="color: black">Content Definition</label></md-checkbox>
 						<br />
+						<md-checkbox class="md-primary"
+							ng-model="tableStyleExportConfig.valueSetsMetadata.oid"
+							ng-change="setChanged()"> <label
+							style="color: black">OID</label></md-checkbox>
+						<br />
+						<md-checkbox class="md-primary"
+							ng-model="tableStyleExportConfig.valueSetsMetadata.type"
+							ng-change="setChanged()"> <label
+							style="color: black">Type</label></md-checkbox>
+						<br />
 					</div>
 				</div>
 			</div>

--- a/igamt-lite-controller/src/main/java/gov/nist/healthcare/tools/hl7/v2/igamt/lite/web/config/Bootstrap.java
+++ b/igamt-lite-controller/src/main/java/gov/nist/healthcare/tools/hl7/v2/igamt/lite/web/config/Bootstrap.java
@@ -1647,7 +1647,7 @@ public class Bootstrap implements InitializingBean {
 
     defaultConfiguration.setValueSetsExport(displaySelectives);
 
-    ValueSetMetadataConfig valueSetMetadataConfig = new ValueSetMetadataConfig(true, true, true);
+    ValueSetMetadataConfig valueSetMetadataConfig = new ValueSetMetadataConfig(true, true, true,true,true);
     defaultConfiguration.setValueSetsMetadata(valueSetMetadataConfig);
 
     // Default column

--- a/igamt-lite-domain/src/main/java/gov/nist/healthcare/tools/hl7/v2/igamt/lite/domain/ExportConfig.java
+++ b/igamt-lite-domain/src/main/java/gov/nist/healthcare/tools/hl7/v2/igamt/lite/domain/ExportConfig.java
@@ -110,7 +110,7 @@ public class ExportConfig {
 
     defaultConfiguration.setValueSetsExport(displaySelectives);
 
-    ValueSetMetadataConfig valueSetMetadataConfig = new ValueSetMetadataConfig(true, true, true);
+    ValueSetMetadataConfig valueSetMetadataConfig = new ValueSetMetadataConfig(true, true, true,true,true);
     defaultConfiguration.setValueSetsMetadata(valueSetMetadataConfig);
 
     // Default column

--- a/igamt-lite-domain/src/main/java/gov/nist/healthcare/tools/hl7/v2/igamt/lite/domain/ValueSetMetadataConfig.java
+++ b/igamt-lite-domain/src/main/java/gov/nist/healthcare/tools/hl7/v2/igamt/lite/domain/ValueSetMetadataConfig.java
@@ -1,13 +1,16 @@
 package gov.nist.healthcare.tools.hl7.v2.igamt.lite.domain;
 
 public class ValueSetMetadataConfig {
-	private boolean stability,extensibility,contentDefinition;
+	private boolean stability,extensibility,contentDefinition,oid,type;
 
-	public ValueSetMetadataConfig(boolean stability, boolean extensibility, boolean contentDefinition) {
+	public ValueSetMetadataConfig(boolean stability, boolean extensibility, boolean contentDefinition, boolean oid,
+			boolean type) {
 		super();
 		this.stability = stability;
 		this.extensibility = extensibility;
 		this.contentDefinition = contentDefinition;
+		this.oid = oid;
+		this.type = type;
 	}
 
 	public ValueSetMetadataConfig() {
@@ -37,5 +40,22 @@ public class ValueSetMetadataConfig {
 	public void setContentDefinition(boolean contentDefinition) {
 		this.contentDefinition = contentDefinition;
 	}
+
+	public boolean isOid() {
+		return oid;
+	}
+
+	public void setOid(boolean oid) {
+		this.oid = oid;
+	}
+
+	public boolean isType() {
+		return type;
+	}
+
+	public void setType(boolean type) {
+		this.type = type;
+	}
+	
 	
 }

--- a/igamt-lite-domain/src/main/java/gov/nist/healthcare/tools/hl7/v2/igamt/lite/domain/serialization/SerializableTable.java
+++ b/igamt-lite-domain/src/main/java/gov/nist/healthcare/tools/hl7/v2/igamt/lite/domain/serialization/SerializableTable.java
@@ -53,7 +53,7 @@ public class SerializableTable extends SerializableSection {
             	valueSetDefinitionElement.addAttribute(new Attribute("SourceType",this.table.getSourceType().name()));
             	if(this.table.getSourceType().equals(Constant.SourceType.EXTERNAL)){
             		if(this.table.getExternalUrl() != null && !this.table.getExternalUrl().isEmpty()){
-            			valueSetDefinitionElement.addAttribute(new Attribute("ExternalUrl",this.table.getExternalUrl()));
+            			valueSetDefinitionElement.addAttribute(new Attribute("ReferenceUrl",this.table.getExternalUrl()));
             		}
             		if(this.table.getContentDefinition().equals(ContentDefinition.Intensional) && this.table.getInfoForExternal() != null && !this.table.getInfoForExternal().isEmpty()){
                     	valueSetDefinitionElement.addAttribute(new Attribute("InfoForExternal",this.table.getInfoForExternal()));

--- a/igamt-lite-domain/src/main/java/gov/nist/healthcare/tools/hl7/v2/igamt/lite/domain/serialization/SerializableTable.java
+++ b/igamt-lite-domain/src/main/java/gov/nist/healthcare/tools/hl7/v2/igamt/lite/domain/serialization/SerializableTable.java
@@ -1,6 +1,8 @@
 package gov.nist.healthcare.tools.hl7.v2.igamt.lite.domain.serialization;
 
 import gov.nist.healthcare.tools.hl7.v2.igamt.lite.domain.Code;
+import gov.nist.healthcare.tools.hl7.v2.igamt.lite.domain.Constant;
+import gov.nist.healthcare.tools.hl7.v2.igamt.lite.domain.ContentDefinition;
 import gov.nist.healthcare.tools.hl7.v2.igamt.lite.domain.Table;
 import gov.nist.healthcare.tools.hl7.v2.igamt.lite.domain.ValueSetMetadataConfig;
 import nu.xom.Attribute;
@@ -46,6 +48,17 @@ public class SerializableTable extends SerializableSection {
                 (this.bindingIdentifier == null) ? "" : table.getBindingIdentifier()));
             if((this.table.getName() != null && !this.table.getName().isEmpty())){
               valueSetDefinitionElement.addAttribute(new Attribute("Name", this.table.getName()));
+            }
+            if(this.table.getSourceType()!=null){
+            	valueSetDefinitionElement.addAttribute(new Attribute("SourceType",this.table.getSourceType().name()));
+            	if(this.table.getSourceType().equals(Constant.SourceType.EXTERNAL)){
+            		if(this.table.getExternalUrl() != null && !this.table.getExternalUrl().isEmpty()){
+            			valueSetDefinitionElement.addAttribute(new Attribute("ExternalUrl",this.table.getExternalUrl()));
+            		}
+            		if(this.table.getContentDefinition().equals(ContentDefinition.Intensional) && this.table.getInfoForExternal() != null && !this.table.getInfoForExternal().isEmpty()){
+                    	valueSetDefinitionElement.addAttribute(new Attribute("InfoForExternal",this.table.getInfoForExternal()));
+                    }
+            	}
             }
             valueSetDefinitionElement.addAttribute(new Attribute("Description",
                 (this.table.getDescription() == null) ? "" : this.table.getDescription()));

--- a/igamt-lite-service/src/main/resources/rendering/generalExport.xsl
+++ b/igamt-lite-service/src/main/resources/rendering/generalExport.xsl
@@ -123,6 +123,10 @@
     <xsl:variable name="valueSetMetadata.extensibility" select="$valueSetMetadataExtensibility"/>
     <xsl:param name="valueSetMetadataContentDefinition" select="'true'"/>
     <xsl:variable name="valueSetMetadata.contentDefinition" select="$valueSetMetadataContentDefinition"/>
+    <xsl:param name="valueSetMetadataOid" select="'true'"/>
+    <xsl:variable name="valueSetMetadata.oid" select="$valueSetMetadataOid"/>
+    <xsl:param name="valueSetMetadataType" select="'true'"/>
+    <xsl:variable name="valueSetMetadata.type" select="$valueSetMetadataType"/>
     
 <!--     <xsl:output method="html" doctype-system="http://www.w3.org/TR/html4/loose.dtd"
    doctype-public="-//W3C//DTD HTML 4.01 Transitional//EN" />

--- a/igamt-lite-service/src/main/resources/rendering/generalExport.xsl
+++ b/igamt-lite-service/src/main/resources/rendering/generalExport.xsl
@@ -12,6 +12,7 @@
     <xsl:param name="inlineConstraints" select="'false'"/>
     <xsl:param name="includeTOC" select="'false'"/>
     <xsl:param name="targetFormat" select="'html'"/>
+    <xsl:variable name="documentTargetFormat" select="$targetFormat"/>
     <xsl:param name="documentTitle" select="'Implementation Guide'"/>
     <xsl:param name="imageLogo" select="''"/>
     <xsl:variable name="inlineConstraintsVar" select="$inlineConstraints"/>

--- a/igamt-lite-service/src/main/resources/rendering/templates/profile/valueSet.xsl
+++ b/igamt-lite-service/src/main/resources/rendering/templates/profile/valueSet.xsl
@@ -31,6 +31,9 @@
         <xsl:choose>
         	<xsl:when test="@SourceType='EXTERNAL'">
         		<xsl:if test="normalize-space(@ExternalUrl)!=''">
+        			<xsl:if test="$documentTargetFormat='word'">
+        				<xsl:element name="br"/>
+        			</xsl:if>
         			<xsl:element name="p">
         				<xsl:element name="b">
         					<xsl:text>URL: </xsl:text>
@@ -47,6 +50,9 @@
         			</xsl:element>
        			</xsl:if>
        			<xsl:if test="@ContentDefinition='Intensional' and normalize-space(@InfoForExternal)!=''">
+		   			<xsl:if test="$documentTargetFormat='word'">
+        				<xsl:element name="br"/>
+        			</xsl:if>
 		   			<xsl:element name="p">
 		   				<xsl:element name="b">
 		   					<xsl:text>Notes: </xsl:text>

--- a/igamt-lite-service/src/main/resources/rendering/templates/profile/valueSet.xsl
+++ b/igamt-lite-service/src/main/resources/rendering/templates/profile/valueSet.xsl
@@ -28,116 +28,146 @@
             <xsl:element name="br"/>
         </xsl:if>
         <xsl:call-template name="valueSetMetadata"/>
-        <xsl:element name="br"/>
-        <xsl:element name="span">
-        	<xsl:attribute name="class">
-        		<xsl:text>contentDiv</xsl:text>
-        	</xsl:attribute>
-            <xsl:element name="span">
-                <xsl:element name="b">
-                    <xsl:text>Codes</xsl:text>
-                </xsl:element>
-            </xsl:element>
-            <xsl:element name="table">
-                <xsl:attribute name="class">
-                    <xsl:text>contentTable</xsl:text>
-                </xsl:attribute>
-                <xsl:attribute name="summary">
-                    <xsl:value-of select="@Description"></xsl:value-of>
-                </xsl:attribute>
-                <xsl:element name="col">
-                    <xsl:attribute name="width">
-                        <xsl:text>15%</xsl:text>
-                    </xsl:attribute>
-                </xsl:element>
-                <xsl:element name="col">
-                    <xsl:attribute name="width">
-                        <xsl:text>15%</xsl:text>
-                    </xsl:attribute>
-                </xsl:element>
-                <xsl:element name="col">
-                    <xsl:attribute name="width">
-                        <xsl:text>10%</xsl:text>
-                    </xsl:attribute>
-                </xsl:element>
-                <xsl:element name="col">
-                    <xsl:attribute name="width">
-                        <xsl:text>40%</xsl:text>
-                    </xsl:attribute>
-                </xsl:element>
-                <xsl:element name="col">
-                    <xsl:attribute name="width">
-                        <xsl:text>20%</xsl:text>
-                    </xsl:attribute>
-                </xsl:element>
-                <xsl:element name="thead">
-                    <xsl:attribute name="class">
-                        <xsl:text>contentThead</xsl:text>
-                    </xsl:attribute>
-                    <xsl:element name="tr">
-                        <xsl:if test="$columnDisplay.valueSet.value = 'true'">
-                            <xsl:element name="th">
-                                <xsl:text>Value</xsl:text>
-                            </xsl:element>
-                        </xsl:if>
-                        <xsl:if test="$columnDisplay.valueSet.codeSystem = 'true'">
-                            <xsl:element name="th">
-                                <xsl:text>Code System</xsl:text>
-                            </xsl:element>
-                        </xsl:if>
-                        <xsl:if test="$columnDisplay.valueSet.usage = 'true'">
-                            <xsl:element name="th">
-                                <xsl:text>Usage</xsl:text>
-                            </xsl:element>
-                        </xsl:if>
-                        <xsl:if test="$columnDisplay.valueSet.description = 'true'">
-                            <xsl:element name="th">
-                                <xsl:text>Description</xsl:text>
-                            </xsl:element>
-                        </xsl:if>
-                        <xsl:if test="$columnDisplay.valueSet.comment = 'true'">
-                            <xsl:element name="th">
-                                <xsl:text>Comment</xsl:text>
-                            </xsl:element>
-                        </xsl:if>
-                    </xsl:element>
-                </xsl:element>
-                <xsl:element name="tbody">
-                    <xsl:for-each select="ValueElement">
-                        <xsl:sort select="@Value" data-type="number"></xsl:sort>
-                        <xsl:call-template name="ValueSetContent"/>
-                    </xsl:for-each>
-                    <xsl:if test="count(ValueElement) = 0">
-                            <xsl:element name="tr">
-                                <xsl:attribute name="class">
-                                    <xsl:text>contentTr</xsl:text>
-                                </xsl:attribute>
-                                <xsl:if test="$columnDisplay.valueSet.value = 'true'">
-                                    <xsl:element name="td">
-                                        <xsl:text></xsl:text>
-                                    </xsl:element>
-                                </xsl:if>
-                                <xsl:if test="$columnDisplay.valueSet.codeSystem = 'true'">
-                                    <xsl:element name="td">
-                                        <xsl:text></xsl:text>
-                                    </xsl:element>
-                                </xsl:if>
-                                <xsl:if test="$columnDisplay.valueSet.usage = 'true'">
-                                    <xsl:element name="td">
-                                        <xsl:text></xsl:text>
-                                    </xsl:element>
-                                </xsl:if>
-                                <xsl:if test="$columnDisplay.valueSet.description = 'true'">
-                                    <xsl:element name="td">
-                                        <xsl:text></xsl:text>
-                                    </xsl:element>
-                                </xsl:if>
-                            </xsl:element>
-
-                    </xsl:if>
-                </xsl:element>
-            </xsl:element>
-        </xsl:element>
+        <xsl:choose>
+        	<xsl:when test="@SourceType='EXTERNAL'">
+        		<xsl:if test="normalize-space(@ExternalUrl)!=''">
+        			<xsl:element name="p">
+        				<xsl:element name="b">
+        					<xsl:text>URL: </xsl:text>
+        				</xsl:element>
+        				<xsl:element name="a">
+        					<xsl:attribute name="href">
+        						<xsl:value-of select="@ExternalUrl"/>
+        					</xsl:attribute>
+        					<xsl:attribute name="target">
+        						<xsl:text>_blank</xsl:text>
+        					</xsl:attribute>
+        					<xsl:value-of select="@ExternalUrl"/>
+        				</xsl:element>
+        			</xsl:element>
+       			</xsl:if>
+       			<xsl:if test="@ContentDefinition='Intensional' and normalize-space(@InfoForExternal)!=''">
+		   			<xsl:element name="p">
+		   				<xsl:element name="b">
+		   					<xsl:text>Notes: </xsl:text>
+		   				</xsl:element>
+		   				<xsl:value-of select="@InfoForExternal"/>
+		   			</xsl:element>
+		   		</xsl:if>
+        	</xsl:when>
+        	<xsl:otherwise>
+        		<xsl:element name="br"/>
+		        <xsl:element name="span">
+		        	<xsl:attribute name="class">
+		        		<xsl:text>contentDiv</xsl:text>
+		        	</xsl:attribute>
+		            <xsl:element name="span">
+		                <xsl:element name="b">
+		                    <xsl:text>Codes</xsl:text>
+		                </xsl:element>
+		            </xsl:element>
+		            <xsl:element name="table">
+		                <xsl:attribute name="class">
+		                    <xsl:text>contentTable</xsl:text>
+		                </xsl:attribute>
+		                <xsl:attribute name="summary">
+		                    <xsl:value-of select="@Description"></xsl:value-of>
+		                </xsl:attribute>
+		                <xsl:element name="col">
+		                    <xsl:attribute name="width">
+		                        <xsl:text>15%</xsl:text>
+		                    </xsl:attribute>
+		                </xsl:element>
+		                <xsl:element name="col">
+		                    <xsl:attribute name="width">
+		                        <xsl:text>15%</xsl:text>
+		                    </xsl:attribute>
+		                </xsl:element>
+		                <xsl:element name="col">
+		                    <xsl:attribute name="width">
+		                        <xsl:text>10%</xsl:text>
+		                    </xsl:attribute>
+		                </xsl:element>
+		                <xsl:element name="col">
+		                    <xsl:attribute name="width">
+		                        <xsl:text>40%</xsl:text>
+		                    </xsl:attribute>
+		                </xsl:element>
+		                <xsl:element name="col">
+		                    <xsl:attribute name="width">
+		                        <xsl:text>20%</xsl:text>
+		                    </xsl:attribute>
+		                </xsl:element>
+		                <xsl:element name="thead">
+		                    <xsl:attribute name="class">
+		                        <xsl:text>contentThead</xsl:text>
+		                    </xsl:attribute>
+		                    <xsl:element name="tr">
+		                        <xsl:if test="$columnDisplay.valueSet.value = 'true'">
+		                            <xsl:element name="th">
+		                                <xsl:text>Value</xsl:text>
+		                            </xsl:element>
+		                        </xsl:if>
+		                        <xsl:if test="$columnDisplay.valueSet.codeSystem = 'true'">
+		                            <xsl:element name="th">
+		                                <xsl:text>Code System</xsl:text>
+		                            </xsl:element>
+		                        </xsl:if>
+		                        <xsl:if test="$columnDisplay.valueSet.usage = 'true'">
+		                            <xsl:element name="th">
+		                                <xsl:text>Usage</xsl:text>
+		                            </xsl:element>
+		                        </xsl:if>
+		                        <xsl:if test="$columnDisplay.valueSet.description = 'true'">
+		                            <xsl:element name="th">
+		                                <xsl:text>Description</xsl:text>
+		                            </xsl:element>
+		                        </xsl:if>
+		                        <xsl:if test="$columnDisplay.valueSet.comment = 'true'">
+		                            <xsl:element name="th">
+		                                <xsl:text>Comment</xsl:text>
+		                            </xsl:element>
+		                        </xsl:if>
+		                    </xsl:element>
+		                </xsl:element>
+		                <xsl:element name="tbody">
+		                    <xsl:for-each select="ValueElement">
+		                        <xsl:sort select="@Value" data-type="number"></xsl:sort>
+		                        <xsl:call-template name="ValueSetContent"/>
+		                    </xsl:for-each>
+		                    <xsl:if test="count(ValueElement) = 0">
+		                            <xsl:element name="tr">
+		                                <xsl:attribute name="class">
+		                                    <xsl:text>contentTr</xsl:text>
+		                                </xsl:attribute>
+		                                <xsl:if test="$columnDisplay.valueSet.value = 'true'">
+		                                    <xsl:element name="td">
+		                                        <xsl:text></xsl:text>
+		                                    </xsl:element>
+		                                </xsl:if>
+		                                <xsl:if test="$columnDisplay.valueSet.codeSystem = 'true'">
+		                                    <xsl:element name="td">
+		                                        <xsl:text></xsl:text>
+		                                    </xsl:element>
+		                                </xsl:if>
+		                                <xsl:if test="$columnDisplay.valueSet.usage = 'true'">
+		                                    <xsl:element name="td">
+		                                        <xsl:text></xsl:text>
+		                                    </xsl:element>
+		                                </xsl:if>
+		                                <xsl:if test="$columnDisplay.valueSet.description = 'true'">
+		                                    <xsl:element name="td">
+		                                        <xsl:text></xsl:text>
+		                                    </xsl:element>
+		                                </xsl:if>
+		                            </xsl:element>
+		
+		                    </xsl:if>
+		                </xsl:element>
+		            </xsl:element>
+		        </xsl:element>
+        	</xsl:otherwise>
+        </xsl:choose>        
         <xsl:if test="count(./Text[@Type='DefPostText']) &gt; 0">
         	<xsl:element name="br"/>
         	<xsl:element name="span">

--- a/igamt-lite-service/src/main/resources/rendering/templates/profile/valueSet.xsl
+++ b/igamt-lite-service/src/main/resources/rendering/templates/profile/valueSet.xsl
@@ -2,6 +2,7 @@
 
     <xsl:import href="/rendering/templates/profile/valueSetContent.xsl"/>
     <xsl:import href="/rendering/templates/profile/valueSetMetadata.xsl"/>
+    <xsl:import href="/rendering/templates/profile/valueSetAttributes.xsl"/>
     <xsl:template match="ValueSetDefinition" mode="toc">
         <xsl:element name="a">
             <xsl:attribute name="href">
@@ -28,24 +29,25 @@
             <xsl:element name="br"/>
         </xsl:if>
         <xsl:call-template name="valueSetMetadata"/>
+        <xsl:call-template name="valueSetAttributes"/>
         <xsl:choose>
         	<xsl:when test="@SourceType='EXTERNAL'">
-        		<xsl:if test="normalize-space(@ExternalUrl)!=''">
+        		<xsl:if test="normalize-space(@ReferenceUrl)!=''">
         			<xsl:if test="$documentTargetFormat='word'">
         				<xsl:element name="br"/>
         			</xsl:if>
         			<xsl:element name="p">
         				<xsl:element name="b">
-        					<xsl:text>URL: </xsl:text>
+        					<xsl:text>Reference URL: </xsl:text>
         				</xsl:element>
         				<xsl:element name="a">
         					<xsl:attribute name="href">
-        						<xsl:value-of select="@ExternalUrl"/>
+        						<xsl:value-of select="@ReferenceUrl"/>
         					</xsl:attribute>
         					<xsl:attribute name="target">
         						<xsl:text>_blank</xsl:text>
         					</xsl:attribute>
-        					<xsl:value-of select="@ExternalUrl"/>
+        					<xsl:value-of select="@ReferenceUrl"/>
         				</xsl:element>
         			</xsl:element>
        			</xsl:if>
@@ -55,8 +57,9 @@
         			</xsl:if>
 		   			<xsl:element name="p">
 		   				<xsl:element name="b">
-		   					<xsl:text>Notes: </xsl:text>
+		   					<xsl:text>Definition text</xsl:text>
 		   				</xsl:element>
+		   				<xsl:element name="br"/>
 		   				<xsl:value-of select="@InfoForExternal"/>
 		   			</xsl:element>
 		   		</xsl:if>

--- a/igamt-lite-service/src/main/resources/rendering/templates/profile/valueSetAttributes.xsl
+++ b/igamt-lite-service/src/main/resources/rendering/templates/profile/valueSetAttributes.xsl
@@ -1,0 +1,64 @@
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+
+    <xsl:template name="valueSetAttributes">
+        <xsl:element name="span">
+        	<xsl:attribute name="class">
+	     		<xsl:text>contentHeader</xsl:text>
+	     	</xsl:attribute>
+            <xsl:element name="b">
+                <xsl:text>Attributes</xsl:text>
+            </xsl:element>
+        </xsl:element>
+        <xsl:element name="table">
+            <xsl:attribute name="class">
+                <xsl:text>contentTable</xsl:text>
+            </xsl:attribute>
+            <xsl:element name="thead">
+                <xsl:attribute name="class">
+                    <xsl:text>contentThead</xsl:text>
+                </xsl:attribute>
+                <xsl:element name="tr">
+                    <xsl:if test="$valueSetMetadata.stability = 'true'">
+                        <xsl:element name="th">
+                            <xsl:text>Stability</xsl:text>
+                        </xsl:element>
+                    </xsl:if>
+                    <xsl:if test="$valueSetMetadata.extensibility = 'true'">
+                        <xsl:element name="th">
+                            <xsl:text>Extensibility</xsl:text>
+                        </xsl:element>
+                    </xsl:if>
+                    <xsl:if test="$valueSetMetadata.contentDefinition = 'true'">
+                        <xsl:element name="th">
+                            <xsl:text>Content Definition</xsl:text>
+                        </xsl:element>
+                    </xsl:if>
+                </xsl:element>
+            </xsl:element>
+            <xsl:element name="tbody">
+                <xsl:element name="tr">
+                    <xsl:attribute name="class">
+                        <xsl:text>contentTr</xsl:text>
+                    </xsl:attribute>
+                    <xsl:if test="$valueSetMetadata.stability = 'true'">
+                        <xsl:element name="th">
+                            <xsl:value-of select="@Stability"/>
+                        </xsl:element>
+                    </xsl:if>
+                    <xsl:if test="$valueSetMetadata.extensibility = 'true'">
+                        <xsl:element name="th">
+                            <xsl:value-of select="@Extensibility"/>
+                        </xsl:element>
+                    </xsl:if>
+                    <xsl:if test="$valueSetMetadata.contentDefinition = 'true'">
+                        <xsl:element name="th">
+                            <xsl:value-of select="@ContentDefinition"/>
+                        </xsl:element>
+                    </xsl:if>
+                </xsl:element>
+            </xsl:element>
+        </xsl:element>
+        <xsl:element name="p"/>
+    </xsl:template>
+
+</xsl:stylesheet>

--- a/igamt-lite-service/src/main/resources/rendering/templates/profile/valueSetMetadata.xsl
+++ b/igamt-lite-service/src/main/resources/rendering/templates/profile/valueSetMetadata.xsl
@@ -9,7 +9,7 @@
                 <xsl:text>Metadata</xsl:text>
             </xsl:element>
         </xsl:element>
-        <xsl:if test="@Oid != '' and @Oid != 'UNSPECIFIED'">
+        <xsl:if test="$valueSetMetadata.oid = 'true' and @Oid != '' and @Oid != 'UNSPECIFIED'">
             <xsl:if test="$documentTargetFormat='word'">
    				<xsl:element name="br"/>
    			</xsl:if>
@@ -20,7 +20,7 @@
 	            <xsl:value-of select="@Oid"/>
             </xsl:element>
         </xsl:if>
-        <xsl:if test="@SourceType != '' and @SourceType != 'UNSPECIFIED'">
+        <xsl:if test="$valueSetMetadata.type = 'true' and @SourceType != '' and @SourceType != 'UNSPECIFIED'">
             <xsl:if test="$documentTargetFormat='word'">
      			<xsl:element name="br"/>
       		</xsl:if>

--- a/igamt-lite-service/src/main/resources/rendering/templates/profile/valueSetMetadata.xsl
+++ b/igamt-lite-service/src/main/resources/rendering/templates/profile/valueSetMetadata.xsl
@@ -9,65 +9,28 @@
                 <xsl:text>Metadata</xsl:text>
             </xsl:element>
         </xsl:element>
-        <xsl:element name="table">
-            <xsl:attribute name="class">
-                <xsl:text>contentTable</xsl:text>
-            </xsl:attribute>
-            <xsl:element name="thead">
-                <xsl:attribute name="class">
-                    <xsl:text>contentThead</xsl:text>
-                </xsl:attribute>
-                <xsl:element name="tr">
-                    <xsl:if test="$valueSetMetadata.stability = 'true'">
-                        <xsl:element name="th">
-                            <xsl:text>Stability</xsl:text>
-                        </xsl:element>
-                    </xsl:if>
-                    <xsl:if test="$valueSetMetadata.extensibility = 'true'">
-                        <xsl:element name="th">
-                            <xsl:text>Extensibility</xsl:text>
-                        </xsl:element>
-                    </xsl:if>
-                    <xsl:if test="$valueSetMetadata.contentDefinition = 'true'">
-                        <xsl:element name="th">
-                            <xsl:text>Content Definition</xsl:text>
-                        </xsl:element>
-                    </xsl:if>
-                    <xsl:if test="@Oid != '' and @Oid != 'UNSPECIFIED'">
-                        <xsl:element name="th">
-                            <xsl:text>OID</xsl:text>
-                        </xsl:element>
-                    </xsl:if>
-                </xsl:element>
+        <xsl:if test="@Oid != '' and @Oid != 'UNSPECIFIED'">
+            <xsl:if test="$documentTargetFormat='word'">
+   				<xsl:element name="br"/>
+   			</xsl:if>
+            <xsl:element name="p">
+	            <xsl:element name="b">
+	                <xsl:text>OID: </xsl:text>
+	            </xsl:element>
+	            <xsl:value-of select="@Oid"/>
             </xsl:element>
-            <xsl:element name="tbody">
-                <xsl:element name="tr">
-                    <xsl:attribute name="class">
-                        <xsl:text>contentTr</xsl:text>
-                    </xsl:attribute>
-                    <xsl:if test="$valueSetMetadata.stability = 'true'">
-                        <xsl:element name="th">
-                            <xsl:value-of select="@Stability"/>
-                        </xsl:element>
-                    </xsl:if>
-                    <xsl:if test="$valueSetMetadata.extensibility = 'true'">
-                        <xsl:element name="th">
-                            <xsl:value-of select="@Extensibility"/>
-                        </xsl:element>
-                    </xsl:if>
-                    <xsl:if test="$valueSetMetadata.contentDefinition = 'true'">
-                        <xsl:element name="th">
-                            <xsl:value-of select="@ContentDefinition"/>
-                        </xsl:element>
-                    </xsl:if>
-                    <xsl:if test="@Oid != '' and @Oid != 'UNSPECIFIED'">
-                        <xsl:element name="th">
-                            <xsl:value-of select="@Oid"/>
-                        </xsl:element>
-                    </xsl:if>
-                </xsl:element>
+        </xsl:if>
+        <xsl:if test="@SourceType != '' and @SourceType != 'UNSPECIFIED'">
+            <xsl:if test="$documentTargetFormat='word'">
+     			<xsl:element name="br"/>
+      		</xsl:if>
+            <xsl:element name="p">
+	            <xsl:element name="b">
+	                <xsl:text>Type: </xsl:text>
+	            </xsl:element>
+	            <xsl:value-of select="@SourceType"/>
             </xsl:element>
-        </xsl:element>
+        </xsl:if>     
         <xsl:element name="p"/>
     </xsl:template>
 


### PR DESCRIPTION
- Create an **external** valueset (or update an existing one that is exported)
- Add source URL
- Create another **external** valueset (or update an existing one that is exported) and set the **content definition to intensional**
- Add source URL
- Add notes
- Create an **internal** valueset (or use an existing one that is exported)
- Check that it is exported correctly in both html and word:

- [ ] First one doesn't have table definition but does have source url

- [ ] Second one doesn't have table definition but does have source url AND notes

- [ ] Third one doesn't have source url nor notes but does have table definition